### PR TITLE
remove list of values for EB solution stack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@ Change Log
 ==========
 
 
+`1.0.1`_ (2017-09-05)
+-----------------------
+
+Bug fixes:
+
+* Remove the drop down list of Multicontainer Docker solution stacks, which was impossible to
+  keep up to date. You'll need to copy/paste the current solution stack name from the `AWS
+  website <http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html#concepts.platforms.mcdocker>`_.
+
 `1.0.0`_ (2017-08-16)
 -----------------------
 
@@ -31,5 +40,6 @@ Backwards-incompatible changes:
 * Initial public release
 
 
+.. _1.0.1: https://aws-container-basics.s3.amazonaws.com/index.html?prefix=1.0.1/
 .. _1.0.0: https://aws-container-basics.s3.amazonaws.com/index.html?prefix=1.0.0/
 .. _0.9.0: https://aws-container-basics.s3.amazonaws.com/index.html?prefix=0.9.0/

--- a/stack/eb.py
+++ b/stack/eb.py
@@ -36,20 +36,12 @@ key_name = template.add_parameter(Parameter(
 
 solution_stack = template.add_parameter(Parameter(
     "SolutionStack",
-    Description="Name of the solution stack to use for this EB environment "
-                "(do NOT change this value after initial stack creation)",
+    Description="Elastic Beanstalk solution stack name (do NOT change after "
+                "stack creation). You most likely want to copy the italicized "
+                "text from: http://docs.aws.amazon.com/elasticbeanstalk/latest"
+                "/dg/concepts.platforms.html#concepts.platforms.mcdocker",
     Type="String",
-    Default="64bit Amazon Linux 2017.03 v2.7.3 running Multi-container Docker 17.03.1-ce (Generic)",
-    AllowedValues=[
-        "64bit Amazon Linux 2017.03 v2.7.3 running Multi-container Docker 17.03.1-ce (Generic)",
-        "64bit Amazon Linux 2016.09 v2.5.2 running Multi-container Docker 1.12.6 (Generic)",
-        "64bit Amazon Linux 2016.09 v2.5.0 running Multi-container Docker 1.12.6 (Generic)",
-        "64bit Amazon Linux 2016.09 v2.4.0 running Multi-container Docker 1.12.6 (Generic)",
-        "64bit Amazon Linux 2016.09 v2.3.0 running Multi-container Docker 1.11.2 (Generic)",
-        "64bit Amazon Linux 2016.03 v2.1.6 running Multi-container Docker 1.11.2 (Generic)",
-        "64bit Amazon Linux 2016.03 v2.1.0 running Multi-container Docker 1.9.1 (Generic)",
-        "64bit Amazon Linux 2015.03 v1.4.6 running Multi-container Docker 1.6.2 (Generic)",
-    ],
+    Default="",
 ))
 
 template.add_mapping("Region2Principal", {


### PR DESCRIPTION
This list turned out to be impossible to keep up to date since Amazon is always changing it, and worse, they decommission some minor releases so they no longer work. Remove the list in favor of looking up the correct stack manually at the provided URL each time an EB stack is created.